### PR TITLE
Fix Name in Desktop file re: Bug 1084864

### DIFF
--- a/MAINTAINER
+++ b/MAINTAINER
@@ -1,1 +1,2 @@
 Petr Gajdos <pgajdos@suse.cz>
+Gerry Makaro <fraser-bell@opensuse.org>

--- a/src/desktop/fonts.desktop
+++ b/src/desktop/fonts.desktop
@@ -17,7 +17,7 @@ X-SuSE-YaST-AutoInstResource=
 Icon=yast-x11
 Exec=xdg-su -c "/sbin/yast2 fonts"
 
-Name=Fonts
-GenericName=Configuring Fonts
+Name=System-Wide Fonts
+GenericName=Configuring System-Wide Fonts
 StartupNotify=true
 


### PR DESCRIPTION
I hope this is acceptable and I hope this works.
Changed name to System-Wide Fonts
Bug 1084864 | YaST module names are too similar to some desktop environment configuration modules